### PR TITLE
Add support for custom look and feel classes and themes

### DIFF
--- a/desktop/src/com/frostwire/desktop/DesktopPlatform.java
+++ b/desktop/src/com/frostwire/desktop/DesktopPlatform.java
@@ -33,6 +33,7 @@ public final class DesktopPlatform extends AbstractPlatform {
     public DesktopPlatform() {
         super(new DefaultFileSystem(), new DesktopPaths(), new DesktopSettings());
         this.vpn = new DesktopVPNMonitor();
+        setLookAndFeel();
     }
 
     @Override
@@ -43,5 +44,16 @@ public final class DesktopPlatform extends AbstractPlatform {
     @Override
     public boolean isUIThread() {
         return SwingUtilities.isEventDispatchThread();
+    }
+
+    private void setLookAndFeel() {
+        String lookAndFeelClassName = ((DesktopSettings) settings()).getLookAndFeelClassName();
+        if (lookAndFeelClassName != null && !lookAndFeelClassName.isEmpty()) {
+            try {
+                UIManager.setLookAndFeel(lookAndFeelClassName);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/desktop/src/com/frostwire/desktop/DesktopPlatform.java
+++ b/desktop/src/com/frostwire/desktop/DesktopPlatform.java
@@ -56,8 +56,4 @@ public final class DesktopPlatform extends AbstractPlatform {
             }
         }
     }
-
-    private DesktopSettings settings() {
-        return (DesktopSettings) super.settings();
-    }
 }

--- a/desktop/src/com/frostwire/desktop/DesktopPlatform.java
+++ b/desktop/src/com/frostwire/desktop/DesktopPlatform.java
@@ -56,4 +56,8 @@ public final class DesktopPlatform extends AbstractPlatform {
             }
         }
     }
+
+    private DesktopSettings settings() {
+        return (DesktopSettings) super.settings();
+    }
 }

--- a/desktop/src/com/frostwire/desktop/DesktopSettings.java
+++ b/desktop/src/com/frostwire/desktop/DesktopSettings.java
@@ -25,6 +25,8 @@ import com.frostwire.platform.AppSettings;
  * @author aldenml
  */
 final class DesktopSettings implements AppSettings {
+    private static final String LOOK_AND_FEEL_CLASS_NAME_KEY = "lookAndFeelClassName";
+
     @Override
     public String string(String key) {
         return null;
@@ -59,5 +61,13 @@ final class DesktopSettings implements AppSettings {
 
     @Override
     public void bool(String key, boolean value) {
+    }
+
+    public String getLookAndFeelClassName() {
+        return string(LOOK_AND_FEEL_CLASS_NAME_KEY);
+    }
+
+    public void setLookAndFeelClassName(String className) {
+        string(LOOK_AND_FEEL_CLASS_NAME_KEY, className);
     }
 }

--- a/desktop/src/com/frostwire/gui/AlphaIcon.java
+++ b/desktop/src/com/frostwire/gui/AlphaIcon.java
@@ -19,6 +19,7 @@ import java.awt.*;
 public class AlphaIcon implements Icon {
     private final Icon icon;
     private final float alpha;
+    private final String lookAndFeelClassName;
 
     /**
      * Creates an <CODE>AlphaIcon</CODE> with the specified icon and opacity.
@@ -27,10 +28,13 @@ public class AlphaIcon implements Icon {
      *
      * @param icon the Icon to wrap
      * @param alpha the opacity
+     * @param lookAndFeelClassName the custom look and feel class name
      */
-    public AlphaIcon(Icon icon, float alpha) {
+    public AlphaIcon(Icon icon, float alpha, String lookAndFeelClassName) {
         this.icon = icon;
         this.alpha = alpha;
+        this.lookAndFeelClassName = lookAndFeelClassName;
+        applyLookAndFeel();
     }
 
     /**
@@ -69,5 +73,18 @@ public class AlphaIcon implements Icon {
     @Override
     public int getIconHeight() {
         return icon.getIconHeight();
+    }
+
+    /**
+     * Applies the custom look and feel class name.
+     */
+    private void applyLookAndFeel() {
+        if (lookAndFeelClassName != null && !lookAndFeelClassName.isEmpty()) {
+            try {
+                UIManager.setLookAndFeel(lookAndFeelClassName);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/desktop/src/com/frostwire/gui/bittorrent/LicenseToggleButton.java
+++ b/desktop/src/com/frostwire/gui/bittorrent/LicenseToggleButton.java
@@ -44,7 +44,7 @@ public class LicenseToggleButton extends JPanel {
         setMeUp();
         licenseIcon = iconName;
         selectedIcon = getIcon(iconName);
-        unselectedIcon = new AlphaIcon(selectedIcon, 0.2f);
+        unselectedIcon = new AlphaIcon(selectedIcon, 0.2f, null);
         iconLabel = new JLabel((selected) ? selectedIcon : unselectedIcon);
         title = text;
         titleLabel = new JLabel("<html><b>" + text + "</b></html>");

--- a/desktop/src/com/frostwire/gui/bittorrent/TransferActionsRenderer.java
+++ b/desktop/src/com/frostwire/gui/bittorrent/TransferActionsRenderer.java
@@ -44,9 +44,9 @@ public final class TransferActionsRenderer extends FWAbstractJPanelTableCellRend
 
     static {
         play_solid = GUIMediator.getThemeImage("search_result_play_over");
-        play_transparent = new AlphaIcon(play_solid, 0.1f);
+        play_transparent = new AlphaIcon(play_solid, 0.1f, null);
         share_solid = GUIMediator.getThemeImage("transfers_sharing_over");
-        share_faded = new AlphaIcon(share_solid, 0.1f);
+        share_faded = new AlphaIcon(share_solid, 0.1f, null);
     }
 
     private JLabel labelPlay;

--- a/desktop/src/com/frostwire/gui/bittorrent/TransferDetailFilesActionsRenderer.java
+++ b/desktop/src/com/frostwire/gui/bittorrent/TransferDetailFilesActionsRenderer.java
@@ -42,9 +42,9 @@ public class TransferDetailFilesActionsRenderer extends FWAbstractJPanelTableCel
 
     static {
         play_solid = GUIMediator.getThemeImage("search_result_play_over");
-        play_transparent = new AlphaIcon(play_solid, 0.1f);
+        play_transparent = new AlphaIcon(play_solid, 0.1f, null);
         share_solid = GUIMediator.getThemeImage("transfers_sharing_over");
-        share_faded = new AlphaIcon(share_solid, 0.1f);
+        share_faded = new AlphaIcon(share_solid, 0.1f, null);
     }
 
     private final JLabel playButton;

--- a/desktop/src/com/frostwire/gui/bittorrent/TransferSeedingRenderer.java
+++ b/desktop/src/com/frostwire/gui/bittorrent/TransferSeedingRenderer.java
@@ -40,7 +40,7 @@ public final class TransferSeedingRenderer extends FWAbstractJPanelTableCellRend
 
     static {
         seed_solid = GUIMediator.getThemeImage("transfers_seeding_over");
-        seed_faded = new AlphaIcon(seed_solid, 0.5f);
+        seed_faded = new AlphaIcon(seed_solid, 0.5f, null);
         loading = GUIMediator.getThemeImage("indeterminate_small_progress");
     }
 

--- a/desktop/src/com/limegroup/gnutella/gui/search/SearchResultActionsRenderer.java
+++ b/desktop/src/com/limegroup/gnutella/gui/search/SearchResultActionsRenderer.java
@@ -54,11 +54,11 @@ public final class SearchResultActionsRenderer extends FWAbstractJPanelTableCell
 
     static {
         play_solid = GUIMediator.getThemeImage("search_result_play_over");
-        play_transparent = new AlphaIcon(play_solid, BUTTONS_TRANSPARENCY);
+        play_transparent = new AlphaIcon(play_solid, BUTTONS_TRANSPARENCY, null);
         download_solid = GUIMediator.getThemeImage("search_result_download_over");
-        download_transparent = new AlphaIcon(download_solid, BUTTONS_TRANSPARENCY);
+        download_transparent = new AlphaIcon(download_solid, BUTTONS_TRANSPARENCY, null);
         details_solid = GUIMediator.getThemeImage("search_result_details_over");
-        details_transparent = new AlphaIcon(details_solid, BUTTONS_TRANSPARENCY);
+        details_transparent = new AlphaIcon(details_solid, BUTTONS_TRANSPARENCY, null);
         speaker_icon = GUIMediator.getThemeImage("speaker");
     }
 

--- a/desktop/src/com/limegroup/gnutella/gui/tables/AbstractActionsRenderer.java
+++ b/desktop/src/com/limegroup/gnutella/gui/tables/AbstractActionsRenderer.java
@@ -43,9 +43,9 @@ public abstract class AbstractActionsRenderer extends FWAbstractJPanelTableCellR
 
     static {
         play_solid = GUIMediator.getThemeImage("search_result_play_over");
-        play_transparent = new AlphaIcon(play_solid, BUTTONS_TRANSPARENCY);
+        play_transparent = new AlphaIcon(play_solid, BUTTONS_TRANSPARENCY, null);
         download_solid = GUIMediator.getThemeImage("search_result_download_over");
-        download_transparent = new AlphaIcon(download_solid, BUTTONS_TRANSPARENCY);
+        download_transparent = new AlphaIcon(download_solid, BUTTONS_TRANSPARENCY, null);
         share_solid = GUIMediator.getThemeImage("transfers_sharing_over");
     }
 

--- a/desktop/src/com/limegroup/gnutella/gui/tables/TableActionLabel.java
+++ b/desktop/src/com/limegroup/gnutella/gui/tables/TableActionLabel.java
@@ -44,9 +44,9 @@ public class TableActionLabel extends JLabel {
 
     public TableActionLabel(ImageIcon enabledSolidIcon, ImageIcon disabledSolidIcon) {
         enabledSolid = enabledSolidIcon;
-        enabledTransparent = new AlphaIcon(enabledSolid, BUTTONS_TRANSPARENCY);
+        enabledTransparent = new AlphaIcon(enabledSolid, BUTTONS_TRANSPARENCY, null);
         disabledSolid = disabledSolidIcon;
-        disabledTransparent = new AlphaIcon(disabledSolid, BUTTONS_TRANSPARENCY);
+        disabledTransparent = new AlphaIcon(disabledSolid, BUTTONS_TRANSPARENCY, null);
     }
 
     public void updateActionIcon(boolean enableAction, boolean showSolid) {


### PR DESCRIPTION
Add support for setting custom look and feel classes and themes in the desktop version.

* **DesktopPlatform.java**
  - Add `setLookAndFeel` method to set the custom look and feel.
  - Call `setLookAndFeel` method in the constructor to apply the custom look and feel.

* **DesktopSettings.java**
  - Add a setting for custom look and feel class name.
  - Add `getLookAndFeelClassName` method to retrieve the custom look and feel class name.
  - Add `setLookAndFeelClassName` method to set the custom look and feel class name.

* **AlphaIcon.java**
  - Modify the constructor to accept a custom look and feel class name.
  - Apply the custom look and feel in the `applyLookAndFeel` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gubatron/frostwire/pull/4?shareId=67e37d66-c28b-425c-a557-a5727f279f02).